### PR TITLE
BugFix Set position to the valid questionHolder with Quantum

### DIFF
--- a/Resources/views/new.html.twig
+++ b/Resources/views/new.html.twig
@@ -172,7 +172,7 @@
 
     function setPosition()
     {
-        questionHolder.find('li.question').each(function() {
+        questionHolder{{ quantum }}.find('li.question').each(function() {
             $vic(this).find('.question-position').val($vic('li.question').index($vic(this)));
         });
     }


### PR DESCRIPTION
Currently we define "questionHolder" with a "quantum", it has been forgotten in the setPosition method.